### PR TITLE
[STEP-17] docker를 이용한 kafka 설치, [STEP-18] 카프카의 발행 실패 방지를 위한 Transactional Outbox Pattern 적용 && 발행 실패 케이스를 위한 재처리 구현

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,18 +2,30 @@
   제목은 [(과제 STEP)] (작업한 내용) 로 작성해 주세요
   예시: [STEP-9] 이커머스 시스템 설계 
 -->
-# [STEP-11] 콘서트 예매 시스템 구현에 관련된 동시성 이슈를 제어할 여러가지 락에 관한 보고서 작성
+# [STEP-17] docker를 이용한 kafka 설치
+# [STEP-18] 카프카의 발행 실패 방지를 위한 Transactional Outbox Pattern 적용 && 발행 실패 케이스를 위한 재처리 구현(Scheduler)
 
 ## PR 설명
 <!-- 해당 PR이 왜 발생했고, 어떤부분에 대한 작업인지 작성해주세요. -->
-해당 보고서는 티스토리에 작성하게 되어 주소를 남겼습니다. 낙관적락, 비관적락, 분산락에 대해 공부하면서 개념을 습득하게 되었으나, 비관적락을 제외하고는 코딩을 하고도 구현에 실패해 실패에 관련된 커밋만 올리게 되었습니다. 
-https://skyoungwave.tistory.com/entry/%EC%BD%98%EC%84%9C%ED%8A%B8-%EC%9C%A0%EC%A0%80-%ED%8F%AC%EC%9D%B8%ED%8A%B8-%EC%B6%A9%EC%A0%84-%EB%B0%8F-%EC%A2%8C%EC%84%9D-%EC%98%88%EC%95%BD-%EB%8F%99%EC%8B%9C-%EC%9A%94%EC%B2%AD-%EC%B2%98%EB%A6%AC-%EC%8B%9C%EA%B0%84-%EB%B9%84%EA%B5%90
+해당 과제에서는 [STEP-17] 과 [STEP-18]을 함께 Pull_request 합니다.
+1. [STEP-17]의 경우 kafka controller 와 kafka controller, kafka producer, kafka consumer 구성해서 터미널에서
+curl -X POST "http://localhost:8080/kafka/send?message=HelloKafka"  를 통해 해당 응답 메시지를 확인했습니다.
 
-## 리뷰 포인트
-<!-- 
-    리뷰어가 함께 고민해주었으면 하는 내용을 간략하게 기재해주세요.
-    커밋 링크가 포함되면, 더욱이 효과적일 거예요! 
--->
+2. [STEP-17]에서 kafka test container도 구현하려고 했으나 실패하여, 후에 시도해볼 Try if you want로 남았습니다.
+
+3. [STEP-18]에서는 기존에 구현했던 Transactional outbox pattern을 카프카의 이벤트 발행과 연계해서 개선했습니다.
+4. [STEP-18] outbox save 로직을 spring event Listener에서 before_commit 그리고 kafka 이벤트 발행 로직을 after_commit으로 구현했습니다.
+5. 만약 트랜잭션 commit 이후에 해당 이벤트를 Listener가 읽지 못하는 상황을 발생해 오랫동안 INIT 상태의 이벤트를 체크하기 위해 
+스케줄러에서는 SEND_FAIL 메시지와 INIT 메시지중 지금으로부터 10분을 기준으로 그것보다 오래된 이벤트를 긁어 재발행하도록 구현했습니다.
+6. 그리고 트랜잭션 commit 직후에 (서비스 배포와 같이) 로직을 실행하는 프로세스가 shutdown되는 상황을 방지하고 graceful shutdown이 정상적으로 이루어지도록
+무신사 29cm outbox transaction 적용기를 참고해서 TreadPoolTaskExecutor의 설정을 종료시 대기, 최대 10초까지 대기하도록 구성했습니다.
+
+## Try if you want..
+[과제 제출 이후 해야할 사항 정리]
+1. kafka test container 적용하기.
+2. 30초마다 재시도 처리를 일정 횟수 제한을 둔 뒤 제한을 넘어가는 이벤트를 위해 DLT 적용하기.
+3. 혹은 슬랙 이메일 등을 통한 파이프라인 구축(개념이 부족해 학습 필요..)
+4. 대규모 실시간성 로그를 기록할 있도록 kafka를 통한 파이프라인 구축
  
 
 ## Definition of Done (DoD)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,14 @@ dependencies {
 	compileOnly("org.springframework.boot:spring-boot-starter-web")
 	annotationProcessor("org.projectlombok:lombok")
 	testAnnotationProcessor("org.projectlombok:lombok")
+	implementation("io.micrometer:micrometer-registry-prometheus")
+
+	// kafka
+	testImplementation("org.testcontainers:kafka:1.19.7")
+	testImplementation("org.testcontainers:junit-jupiter:1.19.7")
+
+	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.kafka:spring-kafka") // Kafka 의존성 추가
 }
 
 tasks.withType<JavaCompile> {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,83 @@
-version: '3'
 services:
+  # ✅ Zookeeper (Kafka 실행에 필요)
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    container_name: zookeeper
+    restart: always
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    networks:
+      - monitoring
+
+  # ✅ Kafka
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    container_name: kafka
+    restart: always
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    depends_on:
+      - zookeeper
+    networks:
+      - monitoring
+
+  # ✅ Kafka UI (메시지 확인용)
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    restart: always
+    ports:
+      - "8081:8081"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAP_SERVERS: kafka:9092
+    depends_on:
+      - kafka
+    networks:
+      - monitoring
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: always
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    networks:
+      - monitoring
+    depends_on:
+      - redis
+      - mysql
+      - influxdb
+
   redis:
     image: docker.io/bitnami/redis:7.4
+    container_name: redis
+    restart: always
     environment:
-      # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes
       - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
+      - REDIS_APPENDONLY=no  # 데이터 지속성 유지
     ports:
       - '6379:6379'
     volumes:
-      - 'redis_data:/bitnami/redis/data'
+      - redis_data:/bitnami/redis/data
+    networks:
+      - monitoring
+
   mysql:
     image: mysql:8.0
     container_name: hhplus-concert-reservation-mysql-1
+    restart: always
     ports:
       - "3307:3306"
     environment:
@@ -21,11 +86,76 @@ services:
       - MYSQL_PASSWORD=application
       - MYSQL_DATABASE=hhplus
     volumes:
-      - ./data/mysql/:/var/lib/mysql            # MySQL 데이터 저장
-      - ./init-scripts/:/docker-entrypoint-initdb.d/  # 초기화 스크립트
+      - mysql_data:/var/lib/mysql
+      - ./db-data:/docker-entrypoint-initdb.d
+    networks:
+      - monitoring
+
+  influxdb:
+    image: influxdb:1.8
+    container_name: influxdb
+    restart: always
+    ports:
+      - "8086:8086"
+    environment:
+      - INFLUXDB_DB=k6
+      - INFLUXDB_ADMIN_USER=admin
+      - INFLUXDB_ADMIN_PASSWORD=admin
+    volumes:
+      - influxdb-storage:/var/lib/influxdb
+    networks:
+      - monitoring
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    restart: always
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana-storage:/var/lib/grafana
+    depends_on:
+      - influxdb
+    networks:
+      - monitoring
+
+  mysqld_exporter:
+    image: prom/mysqld-exporter
+    container_name: mysqld_exporter
+    restart: always
+    environment:
+      - DATA_SOURCE_NAME=application:application@(mysql:3306)/hhplus
+    ports:
+      - "9104:9104"
+    networks:
+      - monitoring
+    depends_on:
+      - mysql
+
+  redis_exporter:
+    image: oliver006/redis_exporter
+    container_name: redis_exporter
+    restart: always
+    ports:
+      - "9121:9121"
+    environment:
+      - REDIS_ADDR=redis://redis:6379
+    networks:
+      - monitoring
+    depends_on:
+      - redis
+
 networks:
-  default:
+  monitoring:
     driver: bridge
+
 volumes:
   redis_data:
     driver: local
+  mysql_data:
+    driver: local
+  influxdb-storage:
+  grafana-storage:

--- a/src/main/java/kr/hhplus/be/server/application/Listener/PaymentEventListener.java
+++ b/src/main/java/kr/hhplus/be/server/application/Listener/PaymentEventListener.java
@@ -1,0 +1,49 @@
+package kr.hhplus.be.server.application.Listener;
+import kr.hhplus.be.server.application.kafka.KafkaProducer;
+import kr.hhplus.be.server.domain.apioutbox.ApiOutbox;
+import kr.hhplus.be.server.domain.apioutbox.OutboxStatus;
+import kr.hhplus.be.server.domain.apioutbox.repository.ApiOutboxRepository;
+import kr.hhplus.be.server.domain.event.PaymentCompletedEvent;
+
+import kr.hhplus.be.server.utils.DataPlatFormApiClient;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@Slf4j
+public class PaymentEventListener {
+    private final KafkaProducer kafkaProducer;
+    private final ApiOutboxRepository apiOutboxRepository;
+
+    public PaymentEventListener(KafkaProducer kafkaProducer, ApiOutboxRepository apiOutboxRepository) {
+        this.kafkaProducer = kafkaProducer;
+        this.apiOutboxRepository = apiOutboxRepository;
+    }
+
+    // 1. Outbox 저장 (트랜잭션 중)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void saveOutbox(PaymentCompletedEvent event) {
+        apiOutboxRepository.save(event.getApiOutbox());
+    }
+
+    @Async("taskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void sendReservationDataToPlatform(PaymentCompletedEvent event) {
+        ApiOutbox outbox = apiOutboxRepository.findById(event.getApiOutbox().getId()).orElse(null);
+        if (outbox == null || outbox.getStatus() != OutboxStatus.INIT) return;
+
+        outbox.setStatus(OutboxStatus.PROCESSING);
+        apiOutboxRepository.save(outbox);
+        try {
+            kafkaProducer.sendMessage("payment-topic", outbox.getPayload());
+            outbox.markAsSuccess();
+        } catch (Exception e) {
+            log.error("Kafka 전송 실패: {}", e.getMessage());
+            outbox.markAsFailed();
+        }
+        apiOutboxRepository.save(outbox);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/application/kafka/KafkaMessage.java
+++ b/src/main/java/kr/hhplus/be/server/application/kafka/KafkaMessage.java
@@ -1,0 +1,16 @@
+package kr.hhplus.be.server.application.kafka;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class KafkaMessage {
+    private String key;
+    private String value;
+
+    public KafkaMessage(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/application/kafka/KafkaProducer.java
+++ b/src/main/java/kr/hhplus/be/server/application/kafka/KafkaProducer.java
@@ -1,0 +1,20 @@
+package kr.hhplus.be.server.application.kafka;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@Log4j2
+public class KafkaProducer {
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public KafkaProducer(KafkaTemplate<String, String> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void sendMessage(String topic, String message) {
+        kafkaTemplate.send(topic,message);
+        log.info("Sent Message: {}", message);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/application/publisher/PaymentEventPublisher.java
+++ b/src/main/java/kr/hhplus/be/server/application/publisher/PaymentEventPublisher.java
@@ -1,0 +1,23 @@
+package kr.hhplus.be.server.application.publisher;
+
+import kr.hhplus.be.server.domain.apioutbox.ApiOutbox;
+import kr.hhplus.be.server.domain.common.dto.ReservationServiceResponse;
+import kr.hhplus.be.server.domain.event.PaymentCompletedEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PaymentEventPublisher {
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Autowired
+    public PaymentEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+        this.applicationEventPublisher = applicationEventPublisher;
+    }
+
+    public void publishPaymentCompletedEvent(ReservationServiceResponse reservationServiceResponse, ApiOutbox apiOutbox)  {
+        applicationEventPublisher.publishEvent(new PaymentCompletedEvent(reservationServiceResponse, apiOutbox));
+    }
+}
+

--- a/src/main/java/kr/hhplus/be/server/application/usecase/ApiOutboxCreatedModule.java
+++ b/src/main/java/kr/hhplus/be/server/application/usecase/ApiOutboxCreatedModule.java
@@ -1,0 +1,30 @@
+package kr.hhplus.be.server.application.usecase;
+
+import kr.hhplus.be.server.domain.apioutbox.ApiOutbox;
+import kr.hhplus.be.server.domain.apioutbox.OutboxStatus;
+import kr.hhplus.be.server.domain.apioutbox.repository.ApiOutboxRepository;
+import kr.hhplus.be.server.domain.common.dto.ReservationServiceResponse;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+import static kr.hhplus.be.server.utils.JsonUtil.convertToJson;
+
+@Component
+public class ApiOutboxCreatedModule {
+
+    private final ApiOutboxRepository apiOutboxRepository;
+
+    public ApiOutboxCreatedModule(ApiOutboxRepository apiOutboxRepository) {
+        this.apiOutboxRepository = apiOutboxRepository;
+    }
+
+    public ApiOutbox CreatedApiOutbox(ReservationServiceResponse response) {
+        ApiOutbox apiOutbox = new ApiOutbox();
+        apiOutbox.setStatus(OutboxStatus.READY);
+        apiOutbox.setPayload(convertToJson(response));
+        apiOutbox.setCreateAt(LocalDateTime.now());
+        apiOutboxRepository.save(apiOutbox);
+        return apiOutbox;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/common/config/KafkaConfig.java
+++ b/src/main/java/kr/hhplus/be/server/common/config/KafkaConfig.java
@@ -1,0 +1,67 @@
+package kr.hhplus.be.server.common.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    // Kafka Producer 설정
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    // Kafka Consumer 설정
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        // Consumer 설정에는 ConsumerConfig 사용
+        props.put(org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaListenerContainerFactory<?> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+
+    // Kafka Topic 설정 (자동 생성)
+    @Bean
+    public NewTopic testTopic() {
+        return new NewTopic("test-topic", 1, (short) 1);
+    }
+
+    @Bean
+    public NewTopic paymentTopic() {
+        return new NewTopic("payment-topic", 1, (short) 1);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/common/config/TaskExecutorConfig.java
+++ b/src/main/java/kr/hhplus/be/server/common/config/TaskExecutorConfig.java
@@ -1,0 +1,27 @@
+package kr.hhplus.be.server.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+public class TaskExecutorConfig {
+
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10); // 최대 10개 스레드까지 확장
+        executor.setQueueCapacity(500); // 대기열 500개
+        executor.setThreadNamePrefix("KafkaSender-"); // 스레드 이름 설정
+
+        // Graceful Shutdown 설정
+        executor.setWaitForTasksToCompleteOnShutdown(true); // 종료 시 대기
+        executor.setAwaitTerminationSeconds(10); // 최대 10초까지 종료 대기
+
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/common/scheduler/RetryFailedOutboxMessage.java
+++ b/src/main/java/kr/hhplus/be/server/common/scheduler/RetryFailedOutboxMessage.java
@@ -1,0 +1,48 @@
+package kr.hhplus.be.server.common.scheduler;
+
+
+import kr.hhplus.be.server.application.kafka.KafkaProducer;
+import kr.hhplus.be.server.domain.apioutbox.ApiOutbox;
+import kr.hhplus.be.server.domain.apioutbox.OutboxStatus;
+import kr.hhplus.be.server.domain.apioutbox.repository.ApiOutboxRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class RetryFailedOutboxMessage {
+    private final ApiOutboxRepository apiOutboxRepository;
+    private final KafkaProducer kafkaProducer;
+
+
+    public RetryFailedOutboxMessage(ApiOutboxRepository apiOutboxRepository, KafkaProducer kafkaProducer) {
+        this.apiOutboxRepository = apiOutboxRepository;
+        this.kafkaProducer = kafkaProducer;
+    }
+
+    @Scheduled(fixedRate = 30000) // 30초마다 실행
+    @Transactional
+    public void retryFailedMessages() {
+        List<ApiOutbox> failedMessages = apiOutboxRepository.findByStatus(OutboxStatus.SEND_FAILED);
+        List<ApiOutbox> stuckMessages = apiOutboxRepository.findByStatus(OutboxStatus.INIT)
+                .stream()
+                .filter(msg -> msg.getCreateAt().isBefore(LocalDateTime.now().minusMinutes(10)))
+                .collect(Collectors.toList());
+
+        List<ApiOutbox> retryMessages = new ArrayList<>();
+        retryMessages.addAll(failedMessages);
+        retryMessages.addAll(stuckMessages);
+
+        for (ApiOutbox outbox : retryMessages) {
+            kafkaProducer.sendMessage("payment-topic", outbox.getPayload());
+            outbox.markAsSuccess();
+            apiOutboxRepository.save(outbox);
+        }
+
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/apioutbox/ApiOutbox.java
+++ b/src/main/java/kr/hhplus/be/server/domain/apioutbox/ApiOutbox.java
@@ -1,0 +1,43 @@
+package kr.hhplus.be.server.domain.apioutbox;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "api_outbox")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiOutbox {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createAt = LocalDateTime.now();
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private OutboxStatus status = OutboxStatus.INIT;
+
+    @Column(name = "payload", columnDefinition = "JSON", nullable = false)
+    private String payload;
+
+    private LocalDateTime updatedAt;
+
+    public void markAsSuccess() {
+        this.status = OutboxStatus.SEND_SUCCESS;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void markAsFailed() {
+        this.status = OutboxStatus.SEND_FAILED;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/apioutbox/OutboxStatus.java
+++ b/src/main/java/kr/hhplus/be/server/domain/apioutbox/OutboxStatus.java
@@ -1,0 +1,8 @@
+package kr.hhplus.be.server.domain.apioutbox;
+
+public enum OutboxStatus {
+    INIT, // 트랜잭션이 commit 되었지만, Listenner가 이벤트를 읽기 못한 상태
+    PROCESSING, //Kafka 발행 중, 이 상태를 유지하면 중복 발행 방지
+    SEND_FAILED, //발행 실패, 재시도 가능
+    SEND_SUCCESS, //정상 처리 완료
+}

--- a/src/main/java/kr/hhplus/be/server/domain/apioutbox/repository/ApiOutboxRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/apioutbox/repository/ApiOutboxRepository.java
@@ -1,0 +1,18 @@
+package kr.hhplus.be.server.domain.apioutbox.repository;
+
+import kr.hhplus.be.server.domain.apioutbox.ApiOutbox;
+import kr.hhplus.be.server.domain.apioutbox.OutboxStatus;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface ApiOutboxRepository {
+    Collection<Object> findByCreatedAtBefore(LocalDateTime now, OutboxStatus outboxStatus);
+
+    Optional<ApiOutbox> findById(Long id);
+    void save(ApiOutbox apiOutbox);
+
+    List<ApiOutbox> findByStatus(OutboxStatus outboxStatus);
+}

--- a/src/main/java/kr/hhplus/be/server/domain/event/PaymentCompletedEvent.java
+++ b/src/main/java/kr/hhplus/be/server/domain/event/PaymentCompletedEvent.java
@@ -1,0 +1,22 @@
+package kr.hhplus.be.server.domain.event;
+
+import kr.hhplus.be.server.domain.apioutbox.ApiOutbox;
+import kr.hhplus.be.server.domain.common.dto.ReservationServiceResponse;
+
+public class PaymentCompletedEvent {
+    private final ReservationServiceResponse reservationServiceResponse;
+    private final ApiOutbox apiOutbox;
+
+    public PaymentCompletedEvent(ReservationServiceResponse reservationServiceResponse, ApiOutbox apiOutbox) {
+        this.reservationServiceResponse = reservationServiceResponse;
+        this.apiOutbox = apiOutbox;
+    }
+
+    public ReservationServiceResponse getReservationServiceResponse() {
+        return reservationServiceResponse;
+    }
+
+    public ApiOutbox getApiOutbox() {
+        return apiOutbox;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/kafka/KafkaConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/kafka/KafkaConsumer.java
@@ -1,0 +1,21 @@
+package kr.hhplus.be.server.infrastructure.kafka;
+
+import kr.hhplus.be.server.domain.apioutbox.repository.ApiOutboxRepository;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@Log4j2
+public class KafkaConsumer {
+    @KafkaListener(topics = "test-topic", groupId = "test-group")
+    public void consumeMessage(String message) {
+        log.info("Received message: {}", message);
+    }
+
+    @KafkaListener(topics = "payment-topic", groupId = "payment-group")
+    public void consume(String message) {
+        log.info("Received message: {}", message);
+        // 여기서 추가적으로 필요한 처리를 수행 가능
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/orm/Apioutbox/JpaApiOutboxRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/orm/Apioutbox/JpaApiOutboxRepository.java
@@ -1,0 +1,20 @@
+package kr.hhplus.be.server.infrastructure.orm.Apioutbox;
+
+import kr.hhplus.be.server.domain.apioutbox.ApiOutbox;
+import kr.hhplus.be.server.domain.apioutbox.OutboxStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+
+public interface JpaApiOutboxRepository extends JpaRepository<ApiOutbox, Long> {
+
+    @Query(value = "SELECT * FROM ApiOutbox a WHERE a.outboxStatus = :outboxStatus", nativeQuery = true)
+    List<ApiOutbox> findByStatus(OutboxStatus outboxStatus);
+
+    @Query(value = "SELECT * FROM ApiOutbox a WHERE a.createdAt < :now AND a.outboxStatus = :outboxStatus", nativeQuery = true)
+    Collection<Object> findByCreatedAtBefore(LocalDateTime now, OutboxStatus outboxStatus);
+
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/repository/Apioutbox/ApiOutboxRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/repository/Apioutbox/ApiOutboxRepositoryImpl.java
@@ -1,0 +1,44 @@
+package kr.hhplus.be.server.infrastructure.repository.Apioutbox;
+
+import kr.hhplus.be.server.common.log.AllRequiredLogger;
+import kr.hhplus.be.server.domain.apioutbox.ApiOutbox;
+import kr.hhplus.be.server.domain.apioutbox.OutboxStatus;
+import kr.hhplus.be.server.domain.apioutbox.repository.ApiOutboxRepository;
+import kr.hhplus.be.server.infrastructure.orm.Apioutbox.JpaApiOutboxRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@AllRequiredLogger
+public class ApiOutboxRepositoryImpl implements ApiOutboxRepository {
+
+    private final JpaApiOutboxRepository jpaApiOutboxRepository;
+
+    public ApiOutboxRepositoryImpl(JpaApiOutboxRepository jpaApiOutboxRepository) {
+        this.jpaApiOutboxRepository = jpaApiOutboxRepository;
+    }
+
+    @Override
+    public Collection<Object> findByCreatedAtBefore(LocalDateTime now, OutboxStatus outboxStatus) {
+        return jpaApiOutboxRepository.findByCreatedAtBefore(now, outboxStatus);
+    }
+
+    @Override
+    public Optional<ApiOutbox> findById(Long id) {
+        return jpaApiOutboxRepository.findById(id);
+    }
+
+    @Override
+    public void save(ApiOutbox apiOutbox) {
+        jpaApiOutboxRepository.save(apiOutbox);
+    }
+
+    @Override
+    public List<ApiOutbox> findByStatus(OutboxStatus outboxStatus) {
+        return jpaApiOutboxRepository.findByStatus(outboxStatus);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/interfaces/api/controller/KafkaController.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/api/controller/KafkaController.java
@@ -1,0 +1,23 @@
+package kr.hhplus.be.server.interfaces.api.controller;
+
+import kr.hhplus.be.server.application.kafka.KafkaProducer;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/kafka")
+public class KafkaController {
+    private final KafkaProducer kafkaProducer;
+
+    public KafkaController(KafkaProducer kafkaProducer) {
+        this.kafkaProducer = kafkaProducer;
+    }
+
+    @PostMapping("/send")
+    public String sendMessage(@RequestParam String message) {
+        kafkaProducer.sendMessage("test-topic", message);
+        return "Message sent: " + message;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  kafka:
+    bootstrap-servers: localhost:9092
   api-docs:
     enable: true
     path: /v3/api-docs

--- a/src/test/java/kr/hhplus/be/server/integration/KafkaIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/integration/KafkaIntegrationTest.java
@@ -1,0 +1,84 @@
+package kr.hhplus.be.server.integration;
+
+import kr.hhplus.be.server.application.kafka.KafkaProducer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class KafkaIntegrationTest {
+
+    @Container
+    private static final KafkaContainer kafkaContainer =
+            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest"));
+
+    static {
+        kafkaContainer.start();
+    }
+
+    @DynamicPropertySource
+    static void setKafkaProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.kafka.bootstrap-servers", kafkaContainer::getBootstrapServers);
+    }
+
+    private KafkaConsumer<String, String> consumer;
+
+    @Autowired
+    private KafkaProducer kafkaProducer;
+
+    @BeforeAll
+    void setup() {
+        // kafkaContainer.start(); // 제거
+        // System.setProperty("spring.kafka.bootstrap-servers", kafkaContainer.getBootstrapServers()); // 제거
+
+        // Kafka Consumer 설정
+        Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-group");
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+
+        consumer = new KafkaConsumer<>(props);
+        consumer.subscribe(Collections.singletonList("test-topic"));
+    }
+
+    @AfterAll
+    void tearDown() {
+        consumer.close();
+        kafkaContainer.stop();
+    }
+
+    @Test
+    void testSendAndReceive() {
+        // Given
+        String topic = "test-topic";
+        String message = "Hello, Kafka!";
+
+        // When
+        kafkaProducer.sendMessage(topic, message);
+
+        // Then (메시지 소비)
+        ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(5));
+        assertThat(records.isEmpty()).isFalse();
+        records.forEach(record -> assertThat(record.value()).isEqualTo(message));
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  kafka:
+    bootstrap-servers: localhost:9092
   api-docs:
     enable: true
     path: /v3/api-docs


### PR DESCRIPTION
<!--
  제목은 [(과제 STEP)] (작업한 내용) 로 작성해 주세요
  예시: [STEP-9] 이커머스 시스템 설계 
-->
# [STEP-17] docker를 이용한 kafka 설치, [STEP-18] 카프카의 발행 실패 방지를 위한 Transactional Outbox Pattern 적용 && 발행 실패 케이스를 위한 재처리 구현(Scheduler)

## PR 설명
해당 과제에서는 [STEP-17] 과 [STEP-18]을 함께 Pull_request 합니다.
1. [STEP-17]의 경우 kafka controller 와 kafka controller, kafka producer, kafka consumer 구성해서 터미널에서
curl -X POST "http://localhost:8080/kafka/send?message=HelloKafka"  를 통해 해당 응답 메시지를 확인했습니다.
<img width="604" alt="스크린샷 2025-02-20 오후 10 46 58" src="https://github.com/user-attachments/assets/6fc214bf-1cc2-4676-a23c-8d6cbde5fbb1" />

2. [STEP-17]에서 kafka test container도 구현하려고 했으나 실패하여, 후에 시도해볼 Try if you want로 남았습니다.

3. [STEP-18]에서는 기존에 구현했던 Transactional outbox pattern을 카프카의 이벤트 발행과 연계해서 개선했습니다.
4. [STEP-18] outbox save 로직을 spring event Listener에서 before_commit 그리고 kafka 이벤트 발행 로직을 after_commit으로 구현했습니다.
5. 만약 트랜잭션 commit 이후에 해당 이벤트를 Listener가 읽지 못하는 상황을 발생해 오랫동안 INIT 상태의 이벤트를 체크하기 위해 
스케줄러에서는 SEND_FAIL 메시지와 INIT 메시지중 지금으로부터 10분을 기준으로 그것보다 오래된 이벤트를 긁어 재발행하도록 구현했습니다.
6. 그리고 트랜잭션 commit 직후에 (서비스 배포와 같이) 로직을 실행하는 프로세스가 shutdown되는 상황을 방지하고 graceful shutdown이 정상적으로 이루어지도록
무신사 29cm outbox transaction 적용기를 참고해서 TreadPoolTaskExecutor의 설정을 종료시 대기, 최대 10초까지 대기하도록 구성했습니다.

## Try if you want..
[과제 제출 이후 해야할 사항 정리]
1. kafka test container 적용하기.
2. 30초마다 재시도 처리를 일정 횟수 제한을 둔 뒤 제한을 넘어가는 이벤트를 위해 DLT 적용하기.
-> 아마 outbox에 숫자를 셀 수 있는 필드를 적용해서 1회씩 재발행할 때, 카운트를 올려주는 식으로 구성하지 않을까 싶습니다.
->그리고 5회가 넘으면 "payment-dlt-topic"으로 이벤트 발행.
4. 혹은 슬랙 이메일 등을 통한 파이프라인 구축(개념이 부족해 학습 필요..)
5. 대규모 실시간성 로그를 기록할 있도록 kafka를 통한 파이프라인 구축